### PR TITLE
Seeded database with admin and client roles

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -31,5 +31,7 @@ namespace BackEndCapstone.Data
         public DbSet<BackEndCapstone.Models.Service> Service { get; set; }
 
         public DbSet<BackEndCapstone.Models.Stylist> Stylist { get; set; }
+        
+        public DbSet<BackEndCapstone.Models.ApplicationUser> ApplicationUser { get; set; }
     }
 }

--- a/Data/DbInitializer.cs
+++ b/Data/DbInitializer.cs
@@ -4,26 +4,75 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using BackEndCapstone.Models;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.AspNetCore.Identity;
 
 namespace BackEndCapstone.Data
 {
     public static class DbInitializer 
     {
-        public static void Initialize(IServiceProvider serviceProvider)
+        public static async void Initialize(IServiceProvider serviceProvider)
         {
 
             using (var context = new ApplicationDbContext(serviceProvider.GetRequiredService<DbContextOptions<ApplicationDbContext>>()))
             {
-                // Look for any services.
-                if (context.AppointmentService.Any())
+                var roleStore = new RoleStore<IdentityRole>(context);
+                var userStore = new UserStore<ApplicationUser>(context);
+
+                if (!context.Roles.Any(r => r.Name == "Admin"))
                 {
-                    return;   // DB has been seeded
+                    var role = new IdentityRole { Name = "Admin", NormalizedName = "Admin" };
+                    await roleStore.CreateAsync(role);
                 }
 
-                if (context.Appointment.Any())
+                if (!context.Roles.Any(r => r.Name == "Client"))
                 {
-                    return;   // DB has been seeded
+                    var role = new IdentityRole { Name = "Client", NormalizedName = "Client" };
+                    await roleStore.CreateAsync(role);
                 }
+
+                if (!context.ApplicationUser.Any(u => u.FirstName == "admin"))
+                {
+                    //  This method will be called after migrating to the latest version.
+                    ApplicationUser user = new ApplicationUser {
+                        FirstName = "admin",
+                        LastName = "admin",
+                        UserName = "admin@admin.com",
+                        NormalizedUserName = "ADMIN@ADMIN.COM",
+                        Email = "admin@admin.com",
+                        NormalizedEmail = "ADMIN@ADMIN.COM",
+                        EmailConfirmed = true,
+                        LockoutEnabled = false,
+                        SecurityStamp = Guid.NewGuid().ToString("D")
+                    };
+                    var passwordHash = new PasswordHasher<ApplicationUser>();
+                    user.PasswordHash = passwordHash.HashPassword(user, "admin");
+                    await userStore.CreateAsync(user);
+                    await userStore.AddToRoleAsync(user, "Admin");
+                    await context.SaveChangesAsync();
+                }
+
+                if (!context.ApplicationUser.Any(u => u.FirstName == "test"))
+                {
+                    //  This method will be called after migrating to the latest version.
+                    ApplicationUser user = new ApplicationUser {
+                        FirstName = "test",
+                        LastName = "test",
+                        UserName = "test@test.com",
+                        NormalizedUserName = "TEST@TEST.COM",
+                        Email = "test@test.com",
+                        NormalizedEmail = "TEST@TEST.COM",
+                        EmailConfirmed = true,
+                        LockoutEnabled = false,
+                        SecurityStamp = Guid.NewGuid().ToString("D")
+                    };
+                    var passwordHash = new PasswordHasher<ApplicationUser>();
+                    user.PasswordHash = passwordHash.HashPassword(user, "test");
+                    await userStore.CreateAsync(user);
+                    await userStore.AddToRoleAsync(user, "Client");
+                    await context.SaveChangesAsync();
+                    }
+
                 //Will Load Services to Seed Databse
                 var services = new Service[]
                 {
@@ -87,6 +136,7 @@ namespace BackEndCapstone.Data
                 }
                 context.SaveChanges();
 
+                // Load stylists to seed database
                 var stylists = new Stylist[]
                 {
                     new Stylist { 


### PR DESCRIPTION
Fixed initializer that was duplicating services and stylists. Seeded database with admin and client roles. Set ApplicationUser in ApplicationDbContext file.